### PR TITLE
README with new upstream repository

### DIFF
--- a/README
+++ b/README
@@ -2,5 +2,5 @@
 
 Our git repository has moved, please update!
 
-$ git remote set-url origin git://git.videolan.org/vlmc.git
+$ git remote set-url origin https://code.videolan.org/videolan/vlmc.git
 $ git pull origin master


### PR DESCRIPTION
Closes #3.

I suggest also changing the link in GitHub's header to: https://code.videolan.org/videolan/vlmc
